### PR TITLE
Main documenter program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 # Coverage reports
 tests/.coverage
+
+# Generated RST
+/output/

--- a/cmakedoc/__init__.py
+++ b/cmakedoc/__init__.py
@@ -1,2 +1,3 @@
 from .parser.aggregator import DocumentationAggregator
-
+from .rstwriter import RSTWriter
+from .documenter import Documenter

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -60,5 +60,5 @@ class Documenter(object):
     def process_variable_doc(self, doc):
         d = self.writer.directive("data", f"{doc.varname}")
         d.text(doc.doc)
-        d.text(f"Default value: {doc.value}")
+        d.field("Default value", doc.value)
         d.field("type", doc.type)

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -12,7 +12,6 @@ from .parser.aggregator import FunctionDocumentation, MacroDocumentation, Variab
 class Documenter(object):
     def __init__(self, files, output):
         self.writer = RSTWriter(f"Documentation for file {files[0]}")
-
         #We need a string stream of some kind, FileStream is easiest
         self.input_stream = FileStream(files[0])
 

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -11,6 +11,7 @@ from .parser.aggregator import FunctionDocumentation, MacroDocumentation, Variab
 
 class Documenter(object):
     def __init__(self, files, output):
+        self.output = output
         self.writer = RSTWriter(f"{files[0]}")
         #We need a string stream of some kind, FileStream is easiest
         self.input_stream = FileStream(files[0])
@@ -35,8 +36,10 @@ class Documenter(object):
         #each element is a namedtuple repesenting the type of documentation it is.
         #So far we can document functions, macros, and variables (only strings and lists built using set)
         self.process_docs(self.aggregator.documented)
-        print(self.writer)
-        self.writer.write_to_file("test.rst")
+        if self.output is not None:
+             self.writer.write_to_file(self.output)
+        else:
+             print(self.writer)
 
     def process_docs(self, docs):
         for doc in docs:

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -10,11 +10,10 @@ from .parser.aggregator import DocumentationAggregator
 from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation
 
 class Documenter(object):
-    def __init__(self, files, output):
-        self.output = output
-        self.writer = RSTWriter(f"{files[0]}")
+    def __init__(self, file: str):
+        self.writer = RSTWriter(file)
         #We need a string stream of some kind, FileStream is easiest
-        self.input_stream = FileStream(files[0])
+        self.input_stream = FileStream(file)
 
         #Convert those strings into tokens and build a stream from those
         self.lexer = CMakeLexer(self.input_stream)
@@ -36,10 +35,7 @@ class Documenter(object):
         #each element is a namedtuple repesenting the type of documentation it is.
         #So far we can document functions, macros, and variables (only strings and lists built using set)
         self.process_docs(self.aggregator.documented)
-        if self.output is not None:
-             self.writer.write_to_file(self.output)
-        else:
-             print(self.writer)
+        return self.writer
 
     def process_docs(self, docs):
         for doc in docs:

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -9,8 +9,29 @@ from .rstwriter import RSTWriter
 from .parser.aggregator import DocumentationAggregator
 from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation
 
+
+"""
+This file contains the Documenter class, which combines functionality
+from parser.aggregator and rstwriter to generate RST documentation
+for CMake files.
+
+:Author: Branden Butler
+:License: Apache 2.0
+
+"""
+
+
 class Documenter(object):
+    """
+    Generates RST documentation from aggregated documentation, combining parser.aggregator and rstwriter.
+    """
+
     def __init__(self, file: str, title: str = None):
+        """
+        :param file: CMake file to read documentation from.
+        :param title: RST header title to use in the generated document.
+        """
+
         title =  file if title is None else title
 
         self.writer = RSTWriter(title)
@@ -33,6 +54,12 @@ class Documenter(object):
 
 
     def process(self):
+        """
+        Process Documenter.aggregator.documented and build RST document from it.
+
+        :return: Completed RSTWriter document, also located in Documenter.writer
+        """
+
         #All of the documented commands are now stored in aggregator.documented,
         #each element is a namedtuple repesenting the type of documentation it is.
         #So far we can document functions, macros, and variables (only strings and lists built using set)
@@ -40,7 +67,14 @@ class Documenter(object):
         return self.writer
 
     def process_docs(self, docs):
+        """
+        Loops over document and dispatches each documentation to the respective processor.
+
+        :param docs: List of documentation objects.
+        """
+
         for doc in docs:
+            #Dispatch doc to correct processor
             if isinstance(doc, FunctionDocumentation):
                 self.process_function_doc(doc)
             elif isinstance(doc, MacroDocumentation):
@@ -49,16 +83,38 @@ class Documenter(object):
                 self.process_variable_doc(doc)
 
 
-    def process_function_doc(self, doc):
+    def process_function_doc(self, doc: FunctionDocumentation):
+        """
+        FunctionDocumentation processor. Generates the RST "function" directive.
+
+        :param doc: Documentation for the function
+        :type doc: FunctionDocumentation
+        """
+
         d = self.writer.directive("function", f"{doc.function}({' '.join(doc.params)})")
         d.text(doc.doc)
 
     def process_macro_doc(self, doc):
+        """
+        MacroDocumentation processor. Generates the RST "function" directive containing
+        a "warning" directive explaining that it is a macro.
+
+        :param doc: Documentation for the macro
+        :type doc: MacroDocumentation
+        """
+
         d = self.writer.directive("function", f"{doc.macro}({' '.join(doc.params)})")
         warning = d.directive("warning", "This is a macro, and so does not introduce a new scope.")
         d.text(doc.doc)
 
     def process_variable_doc(self, doc):
+        """
+        VariableDocumentation processor. Generates the RST "data" directive.
+
+        :param doc: Documentation for the variable.
+        :type doc: VariableDocumentation
+        """
+
         d = self.writer.directive("data", f"{doc.varname}")
         d.text(doc.doc)
         d.field("Default value", doc.value)

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -10,8 +10,10 @@ from .parser.aggregator import DocumentationAggregator
 from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation
 
 class Documenter(object):
-    def __init__(self, file: str):
-        self.writer = RSTWriter(file)
+    def __init__(self, file: str, title: str = None):
+        title =  file if title is None else title
+
+        self.writer = RSTWriter(title)
         #We need a string stream of some kind, FileStream is easiest
         self.input_stream = FileStream(file)
 

--- a/cmakedoc/documenter.py
+++ b/cmakedoc/documenter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+import sys
+from antlr4 import *
+from .parser import ParserErrorListener
+from .parser.CMakeLexer import CMakeLexer
+from .parser.CMakeParser import CMakeParser
+from .parser.CMakeListener import CMakeListener
+from .rstwriter import RSTWriter
+from .parser.aggregator import DocumentationAggregator
+from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation
+
+class Documenter(object):
+    def __init__(self, files, output):
+        self.writer = RSTWriter(f"Documentation for file {files[0]}")
+
+        #We need a string stream of some kind, FileStream is easiest
+        self.input_stream = FileStream(files[0])
+
+        #Convert those strings into tokens and build a stream from those
+        self.lexer = CMakeLexer(self.input_stream)
+        self.stream = CommonTokenStream(self.lexer)
+
+        #We now have a stream of CommonToken instead of strings, parsers require this type of stream
+        self.parser = CMakeParser(self.stream)
+        self.parser.addErrorListener(ParserErrorListener())
+        self.tree = self.parser.cmake_file()
+
+        #Hard part is done, we now have a fully useable parse tree, now we just need to walk it
+        self.aggregator = DocumentationAggregator()
+        self.walker = ParseTreeWalker()
+        self.walker.walk(self.aggregator, self.tree)
+
+        #All of the documented commands are now stored in aggregator.documented,
+        #each element is a namedtuple repesenting the type of documentation it is.
+        #So far we can document functions, macros, and variables (only strings and lists built using set)
+        self.process_docs(self.aggregator.documented)
+        print(self.writer)
+
+    def process_docs(self, docs):
+        for doc in docs:
+            if isinstance(doc, FunctionDocumentation):
+                self.process_function_doc(doc)
+            elif isinstance(doc, MacroDocumentation):
+                self.process_macro_doc(doc)
+            elif isinstance(doc, VariableDocumentation):
+                self.process_variable_doc(doc)
+
+
+    def process_function_doc(self, doc):
+        d = self.writer.directive("function", doc.function)
+        d.text(doc.doc)
+
+    def process_macro_doc(self, doc):
+        d = self.writer.directive("function", doc.macro)
+        d.text("This is a MACRO, and so does not introduce a new scope.")
+        d.text(doc.doc)
+
+    def process_variable_doc(self, doc):
+        print(doc)

--- a/cmakedoc/parser/aggregator.py
+++ b/cmakedoc/parser/aggregator.py
@@ -106,6 +106,7 @@ class DocumentationAggregator(CMakeListener):
               if cleaned_line and cleaned_line[0] == " ": #String is not empty and first character is a space
                    cleaned_line = cleaned_line[1:] #Cleans optional singular space
               cleaned_lines.append(cleaned_line)
+         cleaned_lines[-1] = cleaned_lines[-1].rstrip("#]")
          cleaned_doc = "\n".join(cleaned_lines)
          command = ctx.command_invocation().Identifier().getText().lower()
          if f"process_{command}" in dir(self):

--- a/cmakedoc/rstwriter.py
+++ b/cmakedoc/rstwriter.py
@@ -202,8 +202,7 @@ class Paragraph(object):
 		Populates Paragraph.text_string with the
 		RST string cooresponding to this paragraph
 		"""
-
-		self.text_string = self.prefix + self.text
+		self.text_string = "\n".join([self.prefix + text for text in self.text.split("\n")])
 
 	def __str__(self):
 		return self.text_string

--- a/cmakedoc/rstwriter.py
+++ b/cmakedoc/rstwriter.py
@@ -504,7 +504,14 @@ class Directive(RSTWriter):
 		"""
 		self.document.append(Paragraph(txt, self.get_indents(self.indent + 1)))
 
-	def field(self, name, txt):
+	def field(self, name: str, txt: str):
+		"""
+		Add a field to document tree, adds proper indenting for directives.
+
+		:param name: Name of the field
+		:param txt: Text of the field
+		"""
+
 		self.document.append(Field(name, txt, self.get_indents(self.indent + 1)))
 
 	def to_text(self):

--- a/cmakedoc/rstwriter.py
+++ b/cmakedoc/rstwriter.py
@@ -213,10 +213,11 @@ class Field(object):
 	Represents an RST field, such as Author
 	"""
 
-	def __init__(self, field_name, field_text):
+	def __init__(self, field_name, field_text, prefix=""):
 		self.field_name = field_name
 		self.field_text = field_text
 		self.field_string = ""
+		self.prefix = prefix
 		self.build_field_string()
 
 	def build_field_string(self):
@@ -225,7 +226,7 @@ class Field(object):
 		RST string cooresponding to this field
 		"""
 
-		self.field_string = f":{self.field_name}: {self.field_text}"
+		self.field_string = f"\n{self.prefix}:{self.field_name}: {self.field_text}"
 
 	def __str__(self):
 		return self.field_string
@@ -502,6 +503,9 @@ class Directive(RSTWriter):
 		:param txt: Content of the new paragraph.
 		"""
 		self.document.append(Paragraph(txt, self.get_indents(self.indent + 1)))
+
+	def field(self, name, txt):
+		self.document.append(Field(name, txt, self.get_indents(self.indent + 1)))
 
 	def to_text(self):
 		"""

--- a/examples/example.cmake
+++ b/examples/example.cmake
@@ -8,12 +8,14 @@ include_guard()
 #
 # This function's description stays close to idealized formatting and does not do
 # anything fancy.
-
+#
 # :param person: The person this function says hi to
+# :param me: What my name is
 # :type person: string
+# :type me: string
 #]]
-function(say_hi_to person)
-    message("Hi ${person}")
+function(say_hi_to person me)
+    message("Hi ${person}, I am ${me}")
 endfunction()
 
 #[[[

--- a/main.py
+++ b/main.py
@@ -5,26 +5,33 @@ import sys
 import argparse
 import os
 
-if __name__ == "__main__":
+def main(args = sys.argv[1:]):
     parser = argparse.ArgumentParser()
-    parser.add_argument("file", help="CMake file to generate documentation for. If directory, will generate documentation for all .cmake files")
+    parser.add_argument("file", nargs="+", help="CMake file to generate documentation for. If directory, will generate documentation for all .cmake files")
     parser.add_argument("-o", "--output", help="Directory to output generated RST to. If not specified will print to standard output. Output files will have the original filename with the cmake extension replaced by .rst")
     parser.add_argument("-r", "--recursive", help="If specified, will generate documentation for all subdirectories of specified directory recursively", action="store_true")
-    args = parser.parse_args()
-    files = []
-    input_path = os.path.abspath(args.file)
-    trailing_file = os.path.basename(os.path.normpath(input_path))
+    args = parser.parse_args(args)
     output_path = None
     if args.output is not None:
          output_path = os.path.abspath(args.output)
          print(f"Writing RST files to {output_path}")
+
+    for input in args.file:
+         document(input, output_path, args.recursive)
+
+
+def document(file, output_path = None, recursive = None):
+
+    files = []
+    input_path = os.path.abspath(file)
+
     if os.path.isdir(input_path):
         #Walk dir and add cmake files to list
         for root, subdirs, filenames in os.walk(input_path):
              for file in filenames:
                   if "cmake" == file.split(".")[-1].lower():
                        files.append(os.path.join(root, file))
-             if not args.recursive:
+             if not recursive:
                   break
     elif os.path.isfile(input_path):
         files.append(input_path)
@@ -52,3 +59,6 @@ if __name__ == "__main__":
          else: #Output was not specified so print to screen
               print(output_writer)
               print()
+
+if __name__ == "__main__":
+     main()

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     files = []
     input_path = os.path.abspath(args.file)
+    trailing_file = os.path.basename(os.path.normpath(input_path))
     output_path = None
     if args.output is not None:
          output_path = os.path.abspath(args.output)
@@ -32,14 +33,22 @@ if __name__ == "__main__":
         exit(1)
 
     for file in files:
-         documenter = Documenter(file)
+         if os.path.isdir(input_path):
+              header_name = os.path.relpath(file, input_path) #Path to file relative to input_path
+         else:
+              header_name = file
+         documenter = Documenter(file, header_name)
          output_writer = documenter.process()
-         if output_path != None:
+         if output_path != None: #Determine where to place generated RST file
               print(f"Writing for file {file}")
               if os.path.isdir(output_path):
                    output_filename = os.path.join(output_path, ".".join(os.path.basename(file).split(".")[:-1]) + ".rst")
+                   if os.path.isdir(input_path):
+                        subpath = os.path.relpath(file, input_path) #Path to file relative to input_path
+                        output_filename = os.path.join(output_path, os.path.join(os.path.dirname(subpath), ".".join(os.path.basename(file).split(".")[:-1]) + ".rst"))
                    print(f"Writing RST file {output_filename}")
+                   os.makedirs(os.path.dirname(output_filename), exist_ok=True) #Make sure we have all the directories created
                    output_writer.write_to_file(output_filename)
-         else:
+         else: #Output was not specified so print to screen
               print(output_writer)
               print()

--- a/main.py
+++ b/main.py
@@ -1,13 +1,48 @@
 #!/usr/bin/python3
 
+"""
+Generate Sphinx-compatible RST documentation for CMake files.
+Documentation is written in a special form of block comments,
+denoted by the starting characters :code: `#[[[` and ending with the standard :code: `#]]`.
+
+Usage: main.py [-h] [-o OUTPUT] [-r] file [file ...]
+
+positional arguments:
+  file                  CMake file to generate documentation for. If
+                        directory, will generate documentation for all *.cmake
+                        files (case-insensitive)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        Directory to output generated RST to. If not specified
+                        will print to standard output. Output files will have
+                        the original filename with the cmake extension
+                        replaced by .rst
+  -r, --recursive       If specified, will generate documentation for all
+                        subdirectories of specified directory recursively
+
+
+:Author: Branden Butler
+:License: Apache 2.0
+"""
+
 from cmakedoc.documenter import Documenter
 import sys
 import argparse
 import os
 
 def main(args = sys.argv[1:]):
-    parser = argparse.ArgumentParser()
-    parser.add_argument("file", nargs="+", help="CMake file to generate documentation for. If directory, will generate documentation for all .cmake files")
+    """
+    CMake Documentation Generator program entry point.
+
+    :param args: Array of strings containing program arguments, excluding program name. Same format as sys.argv[1:].
+    """
+
+    parser = argparse.ArgumentParser(description="""
+Automatic documentation generator for CMake files. This program generates Sphinx-compatible RST documents, which are incompatible with standard docutils.
+    """)
+    parser.add_argument("file", nargs="+", help="CMake file to generate documentation for. If directory, will generate documentation for all *.cmake files (case-insensitive)")
     parser.add_argument("-o", "--output", help="Directory to output generated RST to. If not specified will print to standard output. Output files will have the original filename with the cmake extension replaced by .rst")
     parser.add_argument("-r", "--recursive", help="If specified, will generate documentation for all subdirectories of specified directory recursively", action="store_true")
     args = parser.parse_args(args)
@@ -17,11 +52,20 @@ def main(args = sys.argv[1:]):
          print(f"Writing RST files to {output_path}")
 
     for input in args.file:
+         #Process all files specified on command line
          document(input, output_path, args.recursive)
 
 
-def document(file, output_path = None, recursive = None):
+def document(file, output_path = None, recursive = False):
+    """
+    Handler for documenting each specified file or directory. Will locate all cmake files in directory
+    (and subdirs if recursive is true) and write generated RST output to corresponding files output_path,
+    or if None will output to standard output.
 
+    :param file: String locating a file or directory to document.
+    :param output_path: String pointing to the directory to place generated files, will output to stdout if None
+    :param recursive: Whether to generate documentation for subdirectories or not.
+    """
     files = []
     input_path = os.path.abspath(file)
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python3
+
+from cmakedoc import documenter
+import sys
+documenter.Documenter(sys.argv[1:], "")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
-from cmakedoc import documenter
+from cmakedoc.documenter import Documenter
 import sys
-documenter.Documenter(sys.argv[1:], "")
+
+if __name__ == "__main__":
+    documenter = Documenter(sys.argv[1:], "")
+    documenter.process()

--- a/main.py
+++ b/main.py
@@ -12,20 +12,34 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--recursive", help="If specified, will generate documentation for all subdirectories of specified directory recursively", action="store_true")
     args = parser.parse_args()
     files = []
-    if os.path.isdir(args.file):
+    input_path = os.path.abspath(args.file)
+    output_path = None
+    if args.output is not None:
+         output_path = os.path.abspath(args.output)
+         print(f"Writing RST files to {output_path}")
+    if os.path.isdir(input_path):
         #Walk dir and add cmake files to list
-        for root, subdirs, filenames in os.walk(args.file):
+        for root, subdirs, filenames in os.walk(input_path):
              for file in filenames:
                   if "cmake" == file.split(".")[-1].lower():
                        files.append(os.path.join(root, file))
              if not args.recursive:
                   break
-    elif os.path.isfile(args.file):
-        files.append(args.file)
+    elif os.path.isfile(input_path):
+        files.append(input_path)
     else:
         print("File is a special file (socket, FIFO, device file) and is unsupported", file=sys.stderr)
         exit(1)
 
-    documenter = Documenter(files, args.output)
-    documenter.process()
-
+    for file in files:
+         documenter = Documenter(file)
+         output_writer = documenter.process()
+         if output_path != None:
+              print(f"Writing for file {file}")
+              if os.path.isdir(output_path):
+                   output_filename = os.path.join(output_path, ".".join(os.path.basename(file).split(".")[:-1]) + ".rst")
+                   print(f"Writing RST file {output_filename}")
+                   output_writer.write_to_file(output_filename)
+         else:
+              print(output_writer)
+              print()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,30 @@
 
 from cmakedoc.documenter import Documenter
 import sys
+import argparse
+import os
 
 if __name__ == "__main__":
-    documenter = Documenter(sys.argv[1:], "")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", help="CMake file to generate documentation for. If directory, will generate documentation for all .cmake files")
+    parser.add_argument("-o", "--output", help="Directory to output generated RST to. If not specified will print to standard output. Output files will have the original filename with the cmake extension replaced by .rst")
+    parser.add_argument("-r", "--recursive", help="If specified, will generate documentation for all subdirectories of specified directory recursively", action="store_true")
+    args = parser.parse_args()
+    files = []
+    if os.path.isdir(args.file):
+        #Walk dir and add cmake files to list
+        for root, subdirs, filenames in os.walk(args.file):
+             for file in filenames:
+                  if "cmake" == file.split(".")[-1].lower():
+                       files.append(os.path.join(root, file))
+             if not args.recursive:
+                  break
+    elif os.path.isfile(args.file):
+        files.append(args.file)
+    else:
+        print("File is a special file (socket, FIFO, device file) and is unsupported", file=sys.stderr)
+        exit(1)
+
+    documenter = Documenter(files, args.output)
     documenter.process()
+


### PR DESCRIPTION
This will be where the main documenter program that combines the documentationaggregator and rstwriter will be developed. Fixes #5 

- [x] Remove `lstrip()` of spaces from doccomments to not interfere with RST whitespace
- [x] Needs to be command-line executable, with help text and argument parsing